### PR TITLE
Improve dates form on registration status page

### DIFF
--- a/src/components/scenes/PavilionRegistration/PavilionRegistrationStatus.jsx
+++ b/src/components/scenes/PavilionRegistration/PavilionRegistrationStatus.jsx
@@ -217,6 +217,13 @@ const PavilionRegistrationStatus = ({ firebase }) => {
               edit it.
             </li>
           </ul>
+        </div>
+      )}
+
+
+      {(user.registrationStatus === RegistrationStatus.FINISHED_ADVANCE
+        || user.registrationStatus === RegistrationStatus.PUBLIC ) && (
+        <div>
           <p className="pavilion-registration-status__waiting-for-approval__text">
             If you have any questions/concerns/thoughts/jokes please
             contact us at bbteam@bangkokbiennial.com . If you need a

--- a/src/components/scenes/PavilionRegistration/PavilionRegistrationStatus.jsx
+++ b/src/components/scenes/PavilionRegistration/PavilionRegistrationStatus.jsx
@@ -164,7 +164,7 @@ const PavilionRegistrationStatus = ({ firebase }) => {
         <Button
           style={{ width: '200px', float: 'left' }}
           onClick={handleOnClick}
-          text="proceed"
+          text="Edit Details"
         />
       )}
       {(user.registrationStatus === RegistrationStatus.FINISHED_ADVANCE

--- a/src/components/scenes/PavilionRegistration/PavilionRegistrationStatus.jsx
+++ b/src/components/scenes/PavilionRegistration/PavilionRegistrationStatus.jsx
@@ -174,7 +174,7 @@ const PavilionRegistrationStatus = ({ firebase }) => {
             Pavilion Dates
           </h3>
           <p className="pavilion-registration-status__cautious-text">
-            May I have your attention, please ?
+            Please fill in the dates for your pavilion
           </p>
           <div className="pavilion-registration-status__date-box">
             {loadSending ? (

--- a/src/components/scenes/PavilionRegistration/PavilionRegistrationStatus.jsx
+++ b/src/components/scenes/PavilionRegistration/PavilionRegistrationStatus.jsx
@@ -167,8 +167,8 @@ const PavilionRegistrationStatus = ({ firebase }) => {
           text="proceed"
         />
       )}
-      {user.registrationStatus ===
-        RegistrationStatus.FINISHED_ADVANCE && (
+      {(user.registrationStatus === RegistrationStatus.FINISHED_ADVANCE
+        || user.registrationStatus === RegistrationStatus.PUBLIC ) && (
         <div className="pavilion-registration-status__waiting-for-approval">
           <p className="pavilion-registration-status__cautious-text">
             May I have your attention, please ?
@@ -187,7 +187,11 @@ const PavilionRegistrationStatus = ({ firebase }) => {
               renderCheckDateBox()
             )}
           </div>
+        </div>
+      )}
 
+      {user.registrationStatus === RegistrationStatus.FINISHED_ADVANCE && (
+        <div>
           <p className="pavilion-registration-status__waiting-for-approval__text">
             Ok! Now you have finished the process of registering your
             Pavilion for BB2020 (Bangkok Biennial 2020). What happens

--- a/src/components/scenes/PavilionRegistration/PavilionRegistrationStatus.jsx
+++ b/src/components/scenes/PavilionRegistration/PavilionRegistrationStatus.jsx
@@ -226,10 +226,10 @@ const PavilionRegistrationStatus = ({ firebase }) => {
         <div>
           <p className="pavilion-registration-status__waiting-for-approval__text">
             If you have any questions/concerns/thoughts/jokes please
-            contact us at bbteam@bangkokbiennial.com . If you need a
-            confirmation letter from us for funding applications of
-            visa applications or anything like that, please also let
-            us know through the same email address.
+            contact us at <a href="mailto:bbteam@bangkokbiennial.com">bbteam@bangkokbiennial.com</a>.
+            If you need a confirmation letter from us for funding
+            applications of visa applications or anything like that,
+            please also let us know through the same email address.
           </p>
         </div>
       )}

--- a/src/components/scenes/PavilionRegistration/PavilionRegistrationStatus.jsx
+++ b/src/components/scenes/PavilionRegistration/PavilionRegistrationStatus.jsx
@@ -162,7 +162,7 @@ const PavilionRegistrationStatus = ({ firebase }) => {
       {user.registrationStatus !==
         RegistrationStatus.FINISHED_ADVANCE && (
         <Button
-          style={{ width: '200px', float: 'left' }}
+          style={{ width: '200px' }}
           onClick={handleOnClick}
           text="Edit Details"
         />

--- a/src/components/scenes/PavilionRegistration/PavilionRegistrationStatus.jsx
+++ b/src/components/scenes/PavilionRegistration/PavilionRegistrationStatus.jsx
@@ -170,6 +170,9 @@ const PavilionRegistrationStatus = ({ firebase }) => {
       {(user.registrationStatus === RegistrationStatus.FINISHED_ADVANCE
         || user.registrationStatus === RegistrationStatus.PUBLIC ) && (
         <div className="pavilion-registration-status__waiting-for-approval">
+          <h3 className="home__title">
+            Pavilion Dates
+          </h3>
           <p className="pavilion-registration-status__cautious-text">
             May I have your attention, please ?
           </p>

--- a/src/components/scenes/PavilionRegistration/PavilionRegistrationStatus.jsx
+++ b/src/components/scenes/PavilionRegistration/PavilionRegistrationStatus.jsx
@@ -162,7 +162,7 @@ const PavilionRegistrationStatus = ({ firebase }) => {
       {user.registrationStatus !==
         RegistrationStatus.FINISHED_ADVANCE && (
         <Button
-          style={{ width: '200px' }}
+          className="pavilion-registration-status__edit-details-btn"
           onClick={handleOnClick}
           text="Edit Details"
         />

--- a/src/components/scenes/PavilionRegistration/PavilionRegistrationStatus.jsx
+++ b/src/components/scenes/PavilionRegistration/PavilionRegistrationStatus.jsx
@@ -22,7 +22,6 @@ const PavilionRegistrationStatus = ({ firebase }) => {
   const [user, setUser] = useState({})
   const [bbTakePlaced, setBbTakePlaced] = useState([])
   const [loadSending, setLoadSending] = useState(false)
-  const [allowedToSubmit, setAllowedToSubmit] = useState(true)
 
   useEffect(() => {
     if (firebase && !_initFirebase) {
@@ -41,7 +40,6 @@ const PavilionRegistrationStatus = ({ firebase }) => {
           const userData = userSnapshot.data()
           if (userData.dateLaunch) {
             setBbTakePlaced(userData.dateLaunch)
-            setAllowedToSubmit(false)
           }
           await setUser(userData)
           setLoading(false)
@@ -105,7 +103,6 @@ const PavilionRegistrationStatus = ({ firebase }) => {
         dateLaunch: bbTakePlaced,
       })
       setLoadSending(false)
-      setAllowedToSubmit(false)
       addToast('Thank you! the information is saved successfully.', {
         appearance: 'success',
       })
@@ -125,30 +122,26 @@ const PavilionRegistrationStatus = ({ firebase }) => {
         select all that apply
       </p>
       <CheckBox
-        disabled={!allowedToSubmit}
         onClick={() => toggle(DateLaunch.OCT31_TO_NOV21_2020)}
         value={isChecked(DateLaunch.OCT31_TO_NOV21_2020)}
         staticLabel="Oct 31st-Nov 21st 2020"
       />
       <CheckBox
-        disabled={!allowedToSubmit}
         onClick={() => toggle(DateLaunch.MAR13_TO_APR3_2021)}
         value={isChecked(DateLaunch.MAR13_TO_APR3_2021)}
         staticLabel="March 13th-April 3rd 2021"
       />
       <CheckBox
-        disabled={!allowedToSubmit}
         onClick={() => toggle(DateLaunch.SEP17_TO_OCT9_2021)}
         value={isChecked(DateLaunch.SEP17_TO_OCT9_2021)}
         staticLabel="Sept 17th-Oct 9th  2021"
       />
       <CheckBox
-        disabled={!allowedToSubmit}
         onClick={() => toggle(DateLaunch.NONE_OF_THE_ABOVE)}
         value={isChecked(DateLaunch.NONE_OF_THE_ABOVE)}
         staticLabel="none of the above"
       />
-      <Button disabled={!allowedToSubmit} onClick={onSubmit}>
+      <Button onClick={onSubmit}>
         submit
       </Button>
     </>

--- a/src/components/scenes/PavilionRegistration/PavilionRegistrationStatus.jsx
+++ b/src/components/scenes/PavilionRegistration/PavilionRegistrationStatus.jsx
@@ -82,7 +82,7 @@ const PavilionRegistrationStatus = ({ firebase }) => {
       case RegistrationStatus.FINISHED_ADVANCE:
         return '3/3 - wait for the approval to go public.'
       case RegistrationStatus.PUBLIC:
-        return 'your pavilion is approved! - you can edit the information by clicking below'
+        return 'your pavilion is approved! - you can edit the information below'
       default:
         return '1/3 - please wait for the next registration.'
     }
@@ -161,11 +161,17 @@ const PavilionRegistrationStatus = ({ firebase }) => {
       </div>
       {user.registrationStatus !==
         RegistrationStatus.FINISHED_ADVANCE && (
+        <div>
+        <h3 className="home__title">
+          Pavilion Details
+        </h3>
+        <p>Update your pavilion information</p>
         <Button
           className="pavilion-registration-status__edit-details-btn"
           onClick={handleOnClick}
           text="Edit Details"
         />
+        </div>
       )}
       {(user.registrationStatus === RegistrationStatus.FINISHED_ADVANCE
         || user.registrationStatus === RegistrationStatus.PUBLIC ) && (

--- a/src/styles/pages/_pavilion-registration-status.scss
+++ b/src/styles/pages/_pavilion-registration-status.scss
@@ -20,10 +20,10 @@
   &__date-box {
     max-width: 500px;
     padding: 15px;
-    border: 2px dashed $color-dangerous;
+    border: 2px dashed $color-main;
     margin-bottom: 40px;
   }
   &__cautious-text {
-    color: $color-dangerous;
+    color: $color-main;
   }
 }

--- a/src/styles/pages/_pavilion-registration-status.scss
+++ b/src/styles/pages/_pavilion-registration-status.scss
@@ -1,6 +1,7 @@
 .pavilion-registration-status {
   &__edit-details-btn {
-    width: 200px;
+    margin: 0;
+    width: 500px;
   }
 
   &____waiting-for-approval {

--- a/src/styles/pages/_pavilion-registration-status.scss
+++ b/src/styles/pages/_pavilion-registration-status.scss
@@ -1,4 +1,8 @@
 .pavilion-registration-status {
+  &__edit-details-btn {
+    width: 200px;
+  }
+
   &____waiting-for-approval {
     margin-top: 30px;
     width: 50%;


### PR DESCRIPTION
Keep date launch form visible and editable on the pavilion register page. Remove red danger styles that could be misinterpreted as an  input error warning. Keep the contact email message visible to public pavilions.